### PR TITLE
fix: ci macami error

### DIFF
--- a/rpc/datasource.go
+++ b/rpc/datasource.go
@@ -155,7 +155,7 @@ func gobDecodeFixNumberPtr(raw interface{}, ty cty.Type) interface{} {
 	switch {
 	case ty.Equals(cty.Number):
 		if bf, ok := raw.(big.Float); ok {
-			return &bf // wrap in pointer
+			return bf // wrap in pointer
 		}
 	case ty.IsMapType():
 		if m, ok := raw.(map[string]interface{}); ok {


### PR DESCRIPTION
## What does this PR do?

If fixes the [inloco/macami ci error](https://github.com/inloco/macami/actions/runs/9022968616/job/24793720171) in CI:
`panic: interface conversion: interface {} is big.Float, not *big.Float`

![image](https://github.com/inloco/packer-plugin-sdk/assets/23252082/4c62ac6d-899c-4ed6-9ea9-30d5b090394e)

